### PR TITLE
Make the image runnable as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,15 @@
-FROM alpine:3.6
-
-ENV NGINX_VERSION release-1.11.13
+FROM alpine:3.9
 
 RUN apk add --no-cache git openldap-dev ca-certificates gcc g++ make pcre-dev linux-headers zlib-dev openssl gettext
 
-RUN mkdir /var/log/nginx \
+RUN \
+  mkdir /var/log/nginx \
 	&& mkdir /etc/nginx \
 	&& cd ~ \
 	&& git clone https://github.com/kvspb/nginx-auth-ldap.git \
 	&& git clone https://github.com/nginx/nginx.git \
 	&& cd ~/nginx \
-	&& git checkout tags/release-1.11.13 \
+	&& git checkout tags/release-1.15.11 \
 	&& ./auto/configure \
 		--add-module=/root/nginx-auth-ldap \
 		--with-http_ssl_module \
@@ -33,15 +32,22 @@ RUN mkdir /var/log/nginx \
 	&& cd .. \
 	&& rm -rf nginx-auth-ldap \
 	&& rm -rf nginx \
-	&& wget -O /tmp/dockerize.tar.gz https://github.com/jwilder/dockerize/releases/download/v0.2.0/dockerize-linux-amd64-v0.2.0.tar.gz \
+	&& wget -O /tmp/dockerize.tar.gz https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-linux-amd64-v0.6.1.tar.gz \
 	&& tar -C /usr/local/bin -xzvf /tmp/dockerize.tar.gz \
-	&& rm -rf /tmp/dockerize.tar.gz
+	&& rm -rf /tmp/dockerize.tar.gz \
+	&& touch /_external-auth-Lw \
+	&& addgroup -S nginx \
+	&& adduser -S -D -H -s /bin/false -G nginx nginx \
+	&& touch /var/log/nginx/access.log /var/log/nginx/error.log \
+	&& chown -R nginx:nginx /etc/nginx /var/log/nginx /usr/local/nginx
 
-EXPOSE 80 443
+EXPOSE 8080
 
 COPY bin/run.sh /run.sh
 COPY bin/nginx.conf /nginx.conf
 
 RUN chmod +x /run.sh
-RUN touch /_external-auth-Lw
+
+USER nginx
+
 CMD ["/run.sh"]

--- a/bin/nginx.conf
+++ b/bin/nginx.conf
@@ -25,7 +25,7 @@ http {
 
     server {
 
-        listen 80;
+        listen 8080;
         server_name localhost;
 
         error_log /var/log/nginx/error.log;


### PR DESCRIPTION
- Upgraded Alpine to *3.9*
- Upgraded nginx to *1.15.13*
- Upgraded dockerize to 0.6.1
- Added nginx user and group
- Listen on *8080* instead of *80*
- Run as nginx

:)